### PR TITLE
New pip resolver for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install --upgrade pip
 
 COPY ./requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt --use-feature=2020-resolver
 
 
 ### Final image --------------------------------------------------------------------------------------


### PR DESCRIPTION
Looks like pip3 is going to use a different
resolution strategy starting Oct 2020
and requires a `--use-feature=2020-resolver`
parameter to be passed to it.

Updating docker file