### PR TITLE
Support for deletion of entries

### DIFF
--- a/src/SlownikPolonijny.Dal/IRepository.cs
+++ b/src/SlownikPolonijny.Dal/IRepository.cs
@@ -25,6 +25,14 @@ namespace SlownikPolonijny.Dal
 
         void UpdateEntry(Entry entry);
 
-        void RemoveEntry(string entryId);
+        void RemoveEntry(string entryId, string userDoingDeletion);
+
+        void RemoveEntry(string entryId)
+            => this.RemoveEntry(entryId, null);
+
+        void RestoreEntry(string entryId, string userDoingRestore);
+
+        void RestoreEntry(string entryId)
+            => this.RestoreEntry(entryId, null);
     }
 }

--- a/src/SlownikPolonijny.Web/Controllers/AdminController.cs
+++ b/src/SlownikPolonijny.Web/Controllers/AdminController.cs
@@ -127,6 +127,54 @@ namespace SlownikPolonijny.Web.Controllers
             return Json(r);
         }
 
+        [Route("/admin/usun/{id}")]
+        [HttpPost]
+        public async Task<IActionResult> Remove(string id)
+        {
+            var r = new AddEntryResultModel();
+            
+            try
+            {
+                var user = await this.GetCurrentUserAsync();
+                _repo.RemoveEntry(id, user.UserName);
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError(ex.ToString());
+                r.Problems.Add("Błąd bazy danych");
+            }
+            
+            return Json(r);
+        }
+
+        [Route("/admin/usunieto/{id}/{name}")]
+        public IActionResult RemoveConfirmation(string id, string name)
+        {
+            ViewData["Entry"] = DashedParameterTransformer.FromDashed(name);
+            ViewData["Id"] = id;
+            return View();
+        }
+
+        [Route("/admin/przywroc/{id}")]
+        [HttpPost]
+        public async Task<IActionResult> Restore(string id)
+        {
+            var r = new AddEntryResultModel();
+            
+            try
+            {
+                var user = await this.GetCurrentUserAsync();
+                _repo.RestoreEntry(id, user.UserName);
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError(ex.ToString());
+                r.Problems.Add("Błąd bazy danych");
+            }
+            
+            return Json(r);
+        }
+
         [Route("/admin/audyt/{id}")]
         [HttpGet]
         public IActionResult Audit(string id)

--- a/src/SlownikPolonijny.Web/Views/Admin/Edit.cshtml
+++ b/src/SlownikPolonijny.Web/Views/Admin/Edit.cshtml
@@ -172,6 +172,10 @@
                 <button type="submit"
                         class="btn btn-success btn-lg"
                         id="submitButton">Zapisz zmiany</button>
+
+                <button type="button"
+                        class="btn btn-danger btn-lg"
+                        id="deleteEntryButton">Usuń hasło</button>
             </div>
         </form>
     </section>
@@ -213,6 +217,41 @@ function hookUpMulti(uiName, dataName, hint) {
         hookUpRemoveButtons(uiName);
     });
     hookUpRemoveButtons(uiName);
+}
+
+function hookUpDeleteEntryButton() {
+    $("#deleteEntryButton").click(function() {
+        var answer = confirm("Czy na pewno chcesz usunąć hasło?");
+        if (answer == true)
+        {
+            $.ajax({
+                    type: "POST",
+                    url:  "@Url.Action("remove", "admin", new { id = @Model.Entry.Id })"
+                })
+                .done(function(resp) {
+                    console.log(resp);
+                    if (resp.success) {
+                        window.location = "@Url.Action("RemoveConfirmation", "Admin", new { id = @Model.Entry.Id, name = @Model.Entry.Name })";
+                    } else {
+                        $("#problems").show();
+                        var pl = $("#problem-list");
+                        pl.children().remove();
+                        for (var i = 0; i < resp.problems.length; ++i) {
+                            pl.append("<li>" + resp.problems[i] + "</li>");
+                        }
+                    }
+                })
+                .fail(function(resp, textStatus, errorThrown) {
+                    console.log(resp);
+                    console.log(resp);
+                    $("#problems").show();
+                    var pl = $("#problem-list");
+                    pl.children().remove();
+                    pl.append("<li>" + textStatus + "</li>");
+                    pl.append("<li>Spróbuj usunąć jeszcze raz</li>");
+                });
+        }
+    })
 }
 
 function hookUpFormSubmit() {
@@ -261,6 +300,7 @@ document.onreadystatechange = () => {
         hookUpMulti("SeeAlso", "SeeAlso", "zobacz też");
 
         hookUpFormSubmit();
+        hookUpDeleteEntryButton();
     }
 };
 </script>

--- a/src/SlownikPolonijny.Web/Views/Admin/RemoveConfirmation.cshtml
+++ b/src/SlownikPolonijny.Web/Views/Admin/RemoveConfirmation.cshtml
@@ -1,0 +1,60 @@
+@{
+    ViewData["Title"] = "Hasło usunięte";
+}
+<h1>Hasło usunięte</h1>
+<p>
+    Hasło <strong>@ViewData["Entry"]</strong> zostało usunięte ze słownika.
+    Możesz je przywrócić klikając poniższy przycisk.
+</p>
+
+<div class="centered-block">
+    <a class="btn btn-success" asp-controller="home" asp-action="random" role="button">
+        Losuj hasło
+    </a>
+    <button type="button" class="btn btn-warning" id="restoreEntryButton">Przywróć usunięte hasło</button>
+</div>
+
+<div class="alert alert-danger" role="alert" id="problems" style="display:none">
+    <h3>Łi hew e problem</h3>
+    <p>Niestety, coś poszło nie tak:</p>
+    <ul id="problem-list">
+    </ul>
+</div>
+
+<script type="text/javascript">
+
+function hookUpRestoreEntryButton() {
+    $("#restoreEntryButton").click(function(ev) {
+        $.ajax({
+            type: "POST",
+            url:  "@Url.Action("Restore", "Admin", new { id = ViewData["Id"]})"
+        })
+        .done(function(resp) {
+            console.log(resp);
+            if (resp.success) {
+                window.location = "@Url.Action("Entry", "Home", new { name = ViewData["Entry"]})";
+            } else {
+                $("#problems").show();
+                var pl = $("#problems-list");
+                pl.children().remove();
+                for (var i = 0; i < resp.problems.length; ++i) {
+                    pl.append("<li>" + resp.problems[i] + "</li>");
+                }
+            }
+        })
+        .fail(function(resp, textStatus, errorThrown) {
+            console.log(resp);
+            $("#problems").show();
+            var pl = $("#problems-list");
+            pl.children().remove();
+            pl.append("<li>" + textStatus + "</li>");
+        });
+    });
+}
+
+document.onreadystatechange = () => {
+    if (document.readyState === 'complete') {
+        hookUpRestoreEntryButton();
+    }
+};
+</script>

--- a/src/SlownikPolonijny.Web/Views/Home/Entry.cshtml
+++ b/src/SlownikPolonijny.Web/Views/Home/Entry.cshtml
@@ -148,11 +148,8 @@
 }
 
 <div class="centered-block">
-    <a class="btn btn-success" asp-action="random" role="button">
+    <a class="btn btn-success" asp-controller="home" asp-action="random" role="button">
         Losuj hasło
-        @* <svg class="bi" width="24" height="24" fill="currentColor">
-            <use xlink:href="/icons/bootstrap-icons.svg#shuffle"/>
-        </svg> *@
     </a>
 </div>
 


### PR DESCRIPTION
- Added ability to remove and restore dictionary entries.
- Deletion is done from edit entry screen.
- Removed entries get added to separate MongoDB collection.
- Added screen that confirms deletion and allows for restore.

Closes #24